### PR TITLE
Support finishPreferencePanel() and onHeaderClick()

### DIFF
--- a/activity/src/main/java/net/mm2d/preference/PreferenceActivityCompat.kt
+++ b/activity/src/main/java/net/mm2d/preference/PreferenceActivityCompat.kt
@@ -114,6 +114,18 @@ open class PreferenceActivityCompat : AppCompatActivity(),
         }
 
     /**
+     * Called when the user selects an item in the header list.  The default
+     * implementation will call either
+     * {@link #startWithFragment(String, Bundle, Fragment, int, int, int)}
+     * or {@link #switchToHeader(Header)} as appropriate.
+     *
+     * @param header The header that was selected.
+     * @param position The header's position in the list.
+     * @return if it returns true, default implementation won't be executed
+     */
+    open fun onHeaderClick(header: Header, position: Int): Boolean = false
+
+    /**
      * Returns true if this activity is currently showing the header list.
      */
     open fun hasHeaders(): Boolean = delegate.hasHeaders()

--- a/activity/src/main/java/net/mm2d/preference/PreferenceActivityCompatDelegate.kt
+++ b/activity/src/main/java/net/mm2d/preference/PreferenceActivityCompatDelegate.kt
@@ -23,7 +23,6 @@ import androidx.activity.OnBackPressedCallback
 import androidx.annotation.IdRes
 import androidx.annotation.XmlRes
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import androidx.lifecycle.Lifecycle.State
@@ -34,7 +33,7 @@ import net.mm2d.preference.PreferenceActivityCompat.Companion.EXTRA_SHOW_FRAGMEN
 import net.mm2d.preference.PreferenceActivityCompat.Companion.EXTRA_SHOW_FRAGMENT_TITLE
 
 internal class PreferenceActivityCompatDelegate(
-    private val activity: FragmentActivity,
+    private val activity: PreferenceActivityCompat,
     private val connector: Connector
 ) {
     private val _headers = ArrayList<Header>()
@@ -231,10 +230,12 @@ internal class PreferenceActivityCompatDelegate(
 
     private fun onListItemClick(position: Int) {
         if (!isResumed) return
-        (listAdapter?.getItem(position) as? Header)?.let { onHeaderClick(it) }
+        (listAdapter?.getItem(position) as? Header)?.let { onHeaderClick(it, position) }
     }
 
-    private fun onHeaderClick(header: Header) {
+    private fun onHeaderClick(header: Header, position: Int) {
+        if(activity.onHeaderClick(header, position)) return
+
         if (header.fragment != null) {
             switchToHeader(header)
         } else {


### PR DESCRIPTION
Adds support for [`onHeaderClick`](https://developer.android.com/reference/android/preference/PreferenceActivity#onHeaderClick(android.preference.PreferenceActivity.Header,%20int)) and [`finishPreferencePanel`](https://developer.android.com/reference/android/preference/PreferenceActivity#finishPreferencePanel(android.app.Fragment,%20int,%20android.content.Intent))
- This `onHeaderClick` returns `boolean` compared to the original one. If true, then the default implementation won't be executed
- finishPreferencePanel works the same way